### PR TITLE
lock: Don't convert periods to commas when calling "haxelib path"

### DIFF
--- a/src/hmm/commands/LockVersionCommand.hx
+++ b/src/hmm/commands/LockVersionCommand.hx
@@ -153,7 +153,7 @@ class LockVersionCommand implements ICommand {
   }
 
   function lockHaxelibVersion(name : String, version: Option<String>) {
-      var result = Shell.haxelibPath(periodsToComma(name), { log: false, throwError: false });
+      var result = Shell.haxelibPath(name, { log: false, throwError: false });
       if (!result.isInstalled) throw new ValidationError('Library $name is not installed', 1);
       var newVersion = result.version;
       


### PR DESCRIPTION
Locking a haxelib with a period used to fail because the `lockHaxelibVersion` incorrectly passed the modified library name (used for the directory name on libraries that contain a period) to a haxelib command 

![Screenshot 2025-07-05 155019](https://github.com/user-attachments/assets/903a860e-ee7d-44b6-9786-eb301d30068c)
